### PR TITLE
Created GameProgressChecker for Opening Sequence Scene

### DIFF
--- a/00 Unity Proj/Package/.idea/.idea.Package/.idea/workspace.xml
+++ b/00 Unity Proj/Package/.idea/.idea.Package/.idea/workspace.xml
@@ -5,9 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="ff1446c4-c84e-4fa9-bebc-5442cda15b9a" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/Assets/Scripts/Quests/GameProgressChecker.cs" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Assets/Scripts/Quests/GameProgressChecker.cs.meta" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Package/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Package/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scenes/GS_Apartment.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/GS_Apartment.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/VFX/FadeScreenMaterial.mat" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/VFX/FadeScreenMaterial.mat" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/OpeningSequence/OpeningSequence.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/OpeningSequence/OpeningSequence.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ProjectSettings/EditorBuildSettings.asset" beforeDir="false" afterPath="$PROJECT_DIR$/ProjectSettings/EditorBuildSettings.asset" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -61,7 +64,7 @@
   "keyToString": {
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "dev",
+    "git-widget-placeholder": "issue/79-quest-line-system",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
@@ -77,6 +80,10 @@
       <option name="WORKING_DIRECTORY" value="C:\Users\nikki\Desktop\Package Build 1" />
       <option name="PASS_PARENT_ENVS" value="1" />
       <option name="USE_EXTERNAL_CONSOLE" value="0" />
+      <option name="ENV_FILE_PATHS" value="" />
+      <option name="REDIRECT_INPUT_PATH" value="" />
+      <option name="PTY_MODE" value="Auto" />
+      <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
     <configuration name="Start Unity" type="RunUnityExe" factoryName="Unity Executable">
@@ -85,6 +92,10 @@
       <option name="WORKING_DIRECTORY" value="C:\Users\nikki\project-raven\00 Unity Proj\Package" />
       <option name="PASS_PARENT_ENVS" value="1" />
       <option name="USE_EXTERNAL_CONSOLE" value="0" />
+      <option name="ENV_FILE_PATHS" value="" />
+      <option name="REDIRECT_INPUT_PATH" value="" />
+      <option name="PTY_MODE" value="Auto" />
+      <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
     <configuration name="Unit Tests (batch mode)" type="RunUnityExe" factoryName="Unity Executable">
@@ -93,6 +104,10 @@
       <option name="WORKING_DIRECTORY" value="C:\Users\nikki\project-raven\00 Unity Proj\Package" />
       <option name="PASS_PARENT_ENVS" value="1" />
       <option name="USE_EXTERNAL_CONSOLE" value="0" />
+      <option name="ENV_FILE_PATHS" value="" />
+      <option name="REDIRECT_INPUT_PATH" value="" />
+      <option name="PTY_MODE" value="Auto" />
+      <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to Unity Editor &amp; Play" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="UNITY_ATTACH_AND_PLAY" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
@@ -106,6 +121,7 @@
       <option name="selectedOptions">
         <list />
       </option>
+      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
@@ -119,6 +135,7 @@
       <option name="selectedOptions">
         <list />
       </option>
+      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to Device" type="UnityDevicePlayer" factoryName="UnityAttachToDevicePlayer">
@@ -161,6 +178,7 @@
       <workItem from="1763501826841" duration="1441000" />
       <workItem from="1763565032354" duration="4845000" />
       <workItem from="1763599354782" duration="399000" />
+      <workItem from="1763656778776" duration="1548000" />
     </task>
     <servers />
   </component>

--- a/00 Unity Proj/Package/Assets/Scenes/GS_Apartment.unity
+++ b/00 Unity Proj/Package/Assets/Scenes/GS_Apartment.unity
@@ -616,6 +616,57 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 58ac37417e60e534f91138088a3e6f70, type: 3}
+--- !u!1 &207974282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207974284}
+  - component: {fileID: 207974285}
+  m_Layer: 0
+  m_Name: GameProgressChecker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &207974284
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207974282}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 36.046604, y: -28.08526, z: 37.655308}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &207974285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207974282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21d55b63a5784c8fb8778aee3ffc4397, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  customSlotDirectory: 
+  questSpreadsheet:
+    m_AssetGUID: 
+    m_SubObjectName: 
+    m_SubObjectType: 
+    m_SubObjectGUID: 
+    m_EditorAssetChanged: 0
 --- !u!1001 &216748591
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1902,7 +1953,6 @@ GameObject:
   m_Component:
   - component: {fileID: 893100043}
   - component: {fileID: 893100042}
-  - component: {fileID: 893100041}
   - component: {fileID: 893100040}
   m_Layer: 0
   m_Name: UI Camera
@@ -1955,14 +2005,6 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
---- !u!81 &893100041
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 893100039}
-  m_Enabled: 1
 --- !u!20 &893100042
 Camera:
   m_ObjectHideFlags: 0
@@ -2657,132 +2699,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1735577896
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1735577897}
-  - component: {fileID: 1735577898}
-  - component: {fileID: 1735577899}
-  m_Layer: 0
-  m_Name: QuestManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1735577897
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1735577896}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.4264469, y: -2.2302413, z: 32.94215}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1735577898
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1735577896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 23247522be584e7f8308646d839d8dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  questsToLoad:
-  - {fileID: 0}
---- !u!114 &1735577899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1735577896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c593457cd8105e148906690e1707c592, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  trigger: 16
-  delayOneFrame: 0
-  condition:
-    luaConditions: []
-    questConditions: []
-    acceptedTags: []
-    acceptedGameObjects: []
-    luaWizardIndex: -1
-    lastEvaluationValue: 0
-  setQuestState: 1
-  questName: 
-  questState: 0
-  setQuestEntryState: 0
-  questEntryNumber: 1
-  questEntryState: 0
-  setAnotherQuestEntryState: 0
-  anotherQuestEntryNumber: 1
-  anotherQuestEntryState: 0
-  luaCode: 
-  sequence: 
-  sequenceSpeaker: {fileID: 0}
-  sequenceListener: {fileID: 0}
-  waitOneFrameOnStartOrEnable: 1
-  alertMessage: 
-  textTable: {fileID: 0}
-  alertDuration: 0
-  sendMessages: []
-  barkSource: 0
-  barkConversation: 
-  barkEntryID: -1
-  barkEntryTitle: 
-  barkText: 
-  barkTextSequence: 
-  barker: {fileID: 0}
-  barkTarget: {fileID: 0}
-  barkOrder: 0
-  allowBarksDuringConversations: 0
-  skipBarkIfNoValidEntries: 0
-  cacheBarkLines: 0
-  conversation: 
-  conversationConversant: {fileID: 0}
-  conversationActor: {fileID: 0}
-  startConversationEntryID: -1
-  startConversationEntryTitle: 
-  overrideDialogueUI: {fileID: 0}
-  exclusive: 0
-  replace: 0
-  queue: 0
-  skipIfNoValidEntries: 0
-  preventRestartOnSameFrameEnded: 0
-  stopConversationOnTriggerExit: 0
-  marginToAllowTriggerExit: 0.2
-  stopConversationIfTooFar: 0
-  maxConversationDistance: 5
-  monitorConversationDistanceFrequency: 1
-  showCursorDuringConversation: 0
-  pauseGameDuringConversation: 0
-  setActiveActions: []
-  setEnabledActions: []
-  setAnimatorStateActions: []
-  onExecute:
-    m_PersistentCalls:
-      m_Calls: []
-  useConversationTitlePicker: 1
-  useBarkTitlePicker: 1
-  useQuestNamePicker: 1
-  selectedDatabase: {fileID: 11400000, guid: dc727b9fc4869a944987de29a86d1187, type: 2}
 --- !u!1 &1771649995 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4147386455925390410, guid: 7a62c62f9314ef7448137bae230f06ba, type: 3}
@@ -3692,6 +3608,6 @@ SceneRoots:
   - {fileID: 1446895819}
   - {fileID: 128252899}
   - {fileID: 850650129}
-  - {fileID: 1735577897}
   - {fileID: 1858535212}
   - {fileID: 12157149}
+  - {fileID: 207974284}

--- a/00 Unity Proj/Package/Assets/Scenes/OpeningSequence/OpeningSequence.unity
+++ b/00 Unity Proj/Package/Assets/Scenes/OpeningSequence/OpeningSequence.unity
@@ -1108,7 +1108,7 @@ PrefabInstance:
     - target: {fileID: -7511558181221131132, guid: f0214769d91d55f449a56ae1c266e9de, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
-      objectReference: {fileID: 2100000, guid: 035385e3d018971459ff4b14c5a8397e, type: 2}
+      objectReference: {fileID: 2100000, guid: f3db3f9c36e98b344a4578c903d56fd6, type: 2}
     - target: {fileID: 919132149155446097, guid: f0214769d91d55f449a56ae1c266e9de, type: 3}
       propertyPath: m_Name
       value: Building Mockup

--- a/00 Unity Proj/Package/Assets/Scripts/Quests/GameProgressChecker.cs
+++ b/00 Unity Proj/Package/Assets/Scripts/Quests/GameProgressChecker.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.SceneManagement;
+
+namespace QuestSystem
+{
+    public class GameProgressChecker : MonoBehaviour
+    {
+        public string customSlotDirectory;
+        [SerializeField] private AssetReferenceSpreadsheet questSpreadsheet;
+        private ES3Spreadsheet progressSheet;
+        private int workIteration;
+        private int homeIteration;
+        private string currentLocation;
+        private string lastLocation;
+        private int currentQuest;
+        private int currentQuestStage;
+
+        private void Awake()
+        {
+            customSlotDirectory = CurrentSaveDirectory.CurrentDirectory;
+            Debug.Log(customSlotDirectory);
+            GetProgressSpreadsheet();
+            GetDayIteration();
+        }
+
+        private void GetProgressSpreadsheet()
+        {
+            if (customSlotDirectory != null)
+            {
+                // Load the progress data into the ES3Spreadsheet
+                var sheet = new ES3Spreadsheet();
+                sheet.Load($"{customSlotDirectory}/myProgressData.csv");
+                progressSheet = sheet;
+            }
+            else
+            {
+                Debug.Log("Custom Slot Directory is null.");
+            }
+        }
+
+        private void GetDayIteration()
+        {
+            for (int i = 0; i < progressSheet.ColumnCount; i++)
+            {
+
+                string rawColumnName = progressSheet.GetCell<string>(i, 0);
+                string columnName = rawColumnName?.Trim();
+
+                switch (columnName)
+                {
+                    // Get workIteration
+                    case "workIteration":
+                        workIteration = progressSheet.GetCell<int>(i, 1);
+                        Debug.Log("workIteration: " + workIteration);
+                        break;
+
+                    // Get homeIteration
+                    case "homeIteration":
+                        homeIteration = progressSheet.GetCell<int>(i, 1);
+                        Debug.Log("workIteration: " + workIteration);
+                        break;
+
+                    // Set currentLocation to the current scene
+                    case "currentLocation":
+                        currentLocation = SceneManager.GetActiveScene().name;
+                        progressSheet.SetCell(i, 1, currentLocation);
+                        Debug.Log("currentLocation in spreadsheet is now " + currentLocation);
+                        break;
+
+                    // Set lastLocation to null
+                    case "lastLocation":
+                        progressSheet.SetCell(i, 1, "null");
+                        Debug.Log("Reached Switch Case for lastLocation");
+                        break;
+
+                    // Get currentQuest
+                    case "currentQuest":
+                        currentQuest = progressSheet.GetCell<int>(i, 1);
+                        Debug.Log("currentQuest: " + currentQuest);
+                        break;
+
+                    // Set currentQuestStage to 0
+                    case "currentQuestStage":
+                        currentQuestStage = progressSheet.GetCell<int>(i, 1);
+                        Debug.Log("currentQuestStage: " + currentQuest);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/00 Unity Proj/Package/Assets/Scripts/Quests/GameProgressChecker.cs.meta
+++ b/00 Unity Proj/Package/Assets/Scripts/Quests/GameProgressChecker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 21d55b63a5784c8fb8778aee3ffc4397
+timeCreated: 1763656837


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/79-quest-line-system`](https://github.com/Nicole-Scalera/project-raven/tree/issue/79-quest-line-system) into [`issue/44-day-cycle-global-save`](https://github.com/Nicole-Scalera/project-raven/tree/issue/44-day-cycle-global-save).
- Created GameProgressChecker.cs.
- This commit is related to #79, which is a sub-issue to [#44](https://github.com/Nicole-Scalera/project-raven/issues/44).

### In-depth Details
- Immediately after the Player creates a new save, they are immediately teleported to the cinematic sequence.
- During that scene, we set the first run of the Player's data.
- This script was created with the intention of checking the data once we get into the apartment, which will trigger the corresponding events for a given day.